### PR TITLE
Tidies the account details layout and the transaction row buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ The landing page lists your accounts with their number, sort code, opening date 
 below, newest first: date, description, category, amount, and the running balance after that
 transaction. Money out is red, money in is green.
 
+The details at the top spread across the width of the window — three to a line on a wide screen, so an
+account fits on two lines — and fold down to one field per line as the window narrows.
+
 An account soon holds thousands of transactions, so the list shows a window of twenty at a time inside
 its own scrolling box, with the column headings staying put above them. Scroll to the bottom of the box
 and the window slides on to older transactions; scroll back up and the earlier ones return. Only twenty
@@ -110,9 +113,12 @@ step it forwards again. The line to their right tells you where you are — *Sho
 before 13/12/2024* — and once you have moved away from the present, a **jump to latest** link brings you
 straight back. Buttons that would take you past the beginning or end of the account are greyed out.
 
-You can edit a transaction's category straight from the list using the dropdown in its row, and save it
-with the button at the end of the row. **Add New Transaction** adds a row you can fill in by hand, for
-anything that did not come from a statement.
+You can edit a transaction's category straight from the list using the dropdown in its row. A save
+button appears at the end of that row as soon as you change something, and goes again if you put it
+back as it was, so at a glance you can see which rows are waiting to be saved. Each row also has a
+delete button; both are icons, and hovering over either one says what it does. **Add New Transaction**
+adds a row you can fill in by hand, for anything that did not come from a statement — it offers its save
+button straight away.
 
 ### Categories
 
@@ -236,7 +242,8 @@ practice one might be a holiday and the next a work trip, and only you know whic
 
 Two ways to fix this.
 
-**One at a time, on the account screen.** Change the dropdown in the transaction's row and press save.
+**One at a time, on the account screen.** Change the dropdown in the transaction's row and press the
+save button that appears at the end of it.
 
 **In bulk, from your hand analysis.** If your spreadsheet already has the right answer for a period you
 have just imported, apply it wholesale:

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -46,6 +46,20 @@ body div.container {
     margin-bottom: 1em; /* Adjust the value as needed */
 }
 
+.account-grid .account-field {
+    display: flex;
+    gap: 0.5em;
+    /* border-box, or the gutter is added to the grid unit's width and a column no longer fits. */
+    box-sizing: border-box;
+    padding-right: 2em;
+    margin-bottom: 0.5em;
+}
+
+/* A fixed label width keeps the values aligned down each column of the grid. */
+.account-grid .account-field-label {
+    flex: 0 0 9.5em;
+}
+
 .credit-sign-container {
     display: inline-flex;
     align-items: center;

--- a/app/assets/stylesheets/div-tables.css
+++ b/app/assets/stylesheets/div-tables.css
@@ -40,6 +40,12 @@
     color: red;
 }
 
+/* A row's save button only means anything once the row has been edited. It keeps its space so the
+   delete button beside it does not move when it appears. */
+.save-button.is-unchanged {
+    visibility: hidden;
+}
+
 /* Date navigation above the transaction list */
 .transaction-nav {
     display: flex;

--- a/app/javascript/controllers/transaction_row_controller.js
+++ b/app/javascript/controllers/transaction_row_controller.js
@@ -1,17 +1,53 @@
 import { Controller } from "@hotwired/stimulus"
 
+// Hidden rather than removed, so the delete button beside it does not move when it appears.
+const UNCHANGED_CLASS = "is-unchanged"
+
+// Keeps the save button out of the way until the row has an edit to save.
+//
+// Every row is a form of its own and the only field a saved transaction exposes is its category, so
+// most rows on screen are never edited and their save button means nothing.
+//
+// What counts as an edit is read back off the fields themselves each time — `defaultValue` and
+// `defaultSelected` hold what the server rendered — rather than being remembered here. The list
+// detaches rows that scroll out of its window and re-attaches them later, which disconnects and
+// reconnects this controller over an edit the reader has not saved yet; recomputing from the fields
+// survives that, where a flag on the instance would not.
 export default class extends Controller {
-  static targets = [ "categoryForm" ]
+    static targets = [ "save" ]
+    static values = {
+        // A row that has never been saved always has something to save.
+        unsaved: { type: Boolean, default: false }
+    }
 
-  connect() {
-    // console.log("Transaction row controller connected", this.element);
-  }
+    connect() {
+        this.refresh()
+    }
 
-  saveCategory(event) {
-    // console.log("Save button clicked, submitting form:", this.categoryFormTarget);
-    // Programmatically submit the form targeted within this controller instance.
-    // requestSubmit() triggers the form's submit event, allowing Turbo Drive
-    // to intercept it just like a regular submit button click.
-    this.categoryFormTarget.requestSubmit();
-  }
+    refresh() {
+        this.saveTarget.classList.toggle(UNCHANGED_CLASS, !this.changed)
+    }
+
+    get changed() {
+        if (this.unsavedValue) return true
+
+        return this.fields.some(field => (
+            field.tagName === "SELECT" ? this.selectChanged(field) : field.value !== field.defaultValue
+        ))
+    }
+
+    // The fields the reader can actually edit: the token and method inputs Rails adds never change.
+    get fields() {
+        return Array.from(this.element.elements).filter(field => (
+            [ "INPUT", "SELECT", "TEXTAREA" ].includes(field.tagName) &&
+            ![ "hidden", "submit", "button" ].includes(field.type)
+        ))
+    }
+
+    // With nothing marked selected the browser picks the first option, which is the blank one.
+    selectChanged(select) {
+        const rendered = Array.from(select.options).find(option => option.defaultSelected)
+
+        return select.value !== (rendered ? rendered.value : "")
+    }
 }

--- a/app/views/accounts/_account.html.erb
+++ b/app/views/accounts/_account.html.erb
@@ -1,30 +1,33 @@
-<div id="<%= dom_id account %>" class="account-grid">
-  <div class="pure-g">
-    <div class="pure-u-1-6"><strong>Name:</strong></div>
-    <div class="pure-u-1-4"><%= account.name %></div>
+<%# The details sit in one grid so they flow across the width available: one field per line on a
+    phone, two from the medium breakpoint, three from the large one — which puts the five fields of a
+    bank account on two lines. %>
+<div id="<%= dom_id account %>" class="account-grid pure-g">
+  <div class="pure-u-1 pure-u-md-1-2 pure-u-lg-1-3 account-field">
+    <strong class="account-field-label">Name:</strong>
+    <span><%= account.name %></span>
   </div>
 
-  <div class="pure-g">
-    <div class="pure-u-1-6"><strong>Account Number:</strong></div>
-    <div class="pure-u-1-4"><%= account.account_number %></div>
+  <div class="pure-u-1 pure-u-md-1-2 pure-u-lg-1-3 account-field">
+    <strong class="account-field-label">Account Number:</strong>
+    <span><%= account.account_number %></span>
   </div>
 
   <% if account.is_a? BankAccount %>
-    <div class="pure-g">
-      <div class="pure-u-1-6"><strong>Sort Code:</strong></div>
-      <div class="pure-u-1-4"><%= account.sortcode %></div>
+    <div class="pure-u-1 pure-u-md-1-2 pure-u-lg-1-3 account-field">
+      <strong class="account-field-label">Sort Code:</strong>
+      <span><%= account.sortcode %></span>
     </div>
   <% end %>
 
-  <div class="pure-g" data-controller="dateinlocale">
-    <div class="pure-u-1-6"><strong>Opening Date:</strong></div>
-    <div class="pure-u-1-4" data-dateinlocale-target="date" data-date="<%= account.opening_date.iso8601 %>">
+  <div class="pure-u-1 pure-u-md-1-2 pure-u-lg-1-3 account-field" data-controller="dateinlocale">
+    <strong class="account-field-label">Opening Date:</strong>
+    <span data-dateinlocale-target="date" data-date="<%= account.opening_date.iso8601 %>">
       <span></span>
-    </div>
+    </span>
   </div>
 
-  <div class="pure-g">
-    <div class="pure-u-1-6"><strong>Opening Balance:</strong></div>
-    <div class="pure-u-1-4"><%= humanized_money_with_symbol(account.opening_balance) %></div>
+  <div class="pure-u-1 pure-u-md-1-2 pure-u-lg-1-3 account-field">
+    <strong class="account-field-label">Opening Balance:</strong>
+    <span><%= humanized_money_with_symbol(account.opening_balance) %></span>
   </div>
 </div>

--- a/app/views/transactions/_transaction_as_row.html.erb
+++ b/app/views/transactions/_transaction_as_row.html.erb
@@ -4,7 +4,10 @@
               url: url, # Explicitly set the URL
               id: dom_id(transaction, transaction.persisted? ? nil : 'new'),
               html: { class: "div-table-row transaction-row" },
-              data: { controller: "dateinlocale", transaction_id: transaction.id} do |f| %>
+              data: { controller: "dateinlocale transaction-row",
+                      action: "input->transaction-row#refresh change->transaction-row#refresh",
+                      transaction_row_unsaved_value: !transaction.persisted?,
+                      transaction_id: transaction.id} do |f| %>
 
   <% transaction_presenter = TransactionPresenter.new(transaction, self, @categories, @account) %>
 
@@ -64,9 +67,10 @@
 
   <%# Actions Column - Use submit button and add delete button %>
   <div class="div-table-col actions-col"> <%# Added a class for potential styling %>
-    <%# Show Save button only for new/editing rows within the form %>
-    <%# Replace text with Material Icon 'check' %>
-    <%= f.button type: :submit, class: "pure-button pure-button-primary pure-button-small", name: "save" do %>
+    <%# Shown by the transaction_row controller once the row has an edit to save %>
+    <%= f.button type: :submit, class: "pure-button pure-button-primary pure-button-small save-button",
+                 name: "save", title: "Save Transaction",
+                 data: { transaction_row_target: "save" } do %>
       <span class="material-symbols-outlined">save</span>
     <% end %>
 
@@ -74,6 +78,7 @@
     <% if transaction.persisted? %>
       <%= link_to account_transaction_path(@account, transaction),
                   class: "pure-button pure-button-error pure-button-small",
+                  title: "Delete Transaction",
                   data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this transaction?" } do %>
         <span class="material-symbols-outlined">delete</span>
       <% end %>

--- a/design_docs/architecture.md
+++ b/design_docs/architecture.md
@@ -236,13 +236,23 @@ One trap worth recording: the query parameter is `as_of`, not `anchor`. Rails re
 URL helpers for the fragment identifier, so `account_path(account, anchor: date)` silently produces
 `/accounts/9#2024-06-05` and the value never reaches `params`.
 
+**A row's save button follows that row's state.** Every row is its own form, and a saved transaction
+exposes only its category, so a button standing on every row said nothing about which rows had been
+edited. The `transaction_row` controller hides it until a field differs from what the server rendered.
+What counts as a difference is recomputed from the fields themselves — `defaultValue` and
+`defaultSelected` hold the rendered state, and the browser keeps them — rather than being remembered on
+the controller instance: windowing detaches and re-attaches rows, which disconnects and reconnects the
+controller over an edit that has not been saved, so a flag held on the instance would be lost in exactly
+the case that matters. The button keeps its space while hidden, so the delete button beside it does not
+move as the reader works down the list.
+
 **Four Stimulus controllers**, each small:
 
 | Controller | Job |
 | --- | --- |
 | `dateinlocale` | Reformats ISO-8601 dates in data attributes to the browser's locale |
 | `csv_analyzer` | Drag-and-drop of detected CSV columns into the definition form |
-| `transaction_row` | Inline editing of a transaction row |
+| `transaction_row` | Offers a row's save button only once the row has an edit to save |
 | `account` | Shows/hides the sort-code field by account type |
 
 **The CSV analysis screen** is the one piece of real interaction design.

--- a/spec/system/transactions_spec.rb
+++ b/spec/system/transactions_spec.rb
@@ -56,6 +56,52 @@ RSpec.describe "Transactions", type: :system do
     expect(transaction.category.name).to eq('Travel')
   end
 
+  describe "the save button" do
+    before { visit account_path(account) }
+
+    let(:row) { find('form.transaction-row', match: :first) }
+
+    it "is out of the way until the row has an edit to save" do
+      within(row) { expect(page).to have_no_button('save') }
+    end
+
+    it "appears once the category is changed" do
+      within(row) do
+        select 'Travel', from: 'transaction[category_id]'
+
+        expect(page).to have_button('save')
+      end
+    end
+
+    it "goes away again when the row is put back as it was" do
+      within(row) do
+        expect(find('select').value).to eq('') # the generated transactions arrive uncategorised
+
+        select 'Travel', from: 'transaction[category_id]'
+        expect(page).to have_button('save')
+
+        find('option[value=""]').select_option
+
+        expect(page).to have_no_button('save')
+      end
+    end
+
+    it "is offered straight away on a row that has never been saved" do
+      click_link 'Add New Transaction'
+
+      within('#new_transaction') { expect(page).to have_button('save') }
+    end
+
+    it "explains itself, as does the delete button beside it" do
+      within(row) do
+        select 'Travel', from: 'transaction[category_id]'
+
+        expect(find_button('save')[:title]).to eq('Save Transaction')
+        expect(find_link('delete')[:title]).to eq('Delete Transaction')
+      end
+    end
+  end
+
   after(:all) do
     Account.destroy_all
   end


### PR DESCRIPTION
Two small UI changes to the account screen.

**The account details lay out across the width available.** The five fields each had their own
`pure-g` row, so they stacked one per line however wide the window was. They now share a single grid:
one field per line on a phone, two from the medium breakpoint, three from the large one — which puts a
bank account on two lines. The gutter needs `box-sizing: border-box`, or it is added outside the grid
unit's percentage width and the third column stops fitting.

**A row's save button is offered only once the row has an edit to save.** Every transaction row is a
form of its own, so each carried a save button whether or not anything had changed — and on a saved row
the only field that can change is the category, so most of those buttons meant nothing. The
`transaction_row` controller (until now dead code) hides the button until a field differs from what the
server rendered; a row that has never been saved always shows it.

What counts as an edit is recomputed from the fields rather than remembered on the controller, because
the windowed list detaches rows that scroll out of view and re-attaches them later — disconnecting and
reconnecting the controller over an edit that has not been saved yet. The button keeps its space while
hidden so the delete button beside it does not move. Both buttons are icons alone, so both now carry a
tooltip.

## Checks

- Full suite green (176 examples), rubocop clean.
- Five new system examples cover the button: hidden initially, appearing on change, disappearing when
  the row is put back as it was, present on a never-saved row, and the tooltips.
- Checked by hand in the browser at 1400/1100/900/500px for the layout, and on the transaction list for
  the button.

`README.md` and `design_docs/architecture.md` are updated in the same change. The layout change is
styling only, so it appears in the README but not the architecture document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)