### PR TITLE
Documents setting up a worktree so the seed has something to read

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,22 @@ encrypted credentials under `seed_data` (`bin/rails credentials:edit`), so seedi
 `config/master.key` and the statement files, both gitignored. Where any of that is absent it reports why
 and does nothing, rather than failing, so a deploy does not fall over before the statements are in place.
 
+### Setting up a new worktree
+
+`config/master.key` and `db/*.csv` are gitignored, so a new worktree has neither, and `db:seed` will
+report that it cannot find them and do nothing — which reads like a broken seed the first time you meet
+it. Symlink them from the main checkout rather than copying, so the real statements exist once on disk:
+
+```sh
+MAIN=$(dirname "$(git rev-parse --git-common-dir)")     # the main checkout, from any worktree
+ln -sfn "$MAIN/config/master.key" config/master.key
+for f in "$MAIN"/db/*.csv; do ln -sfn "$f" "db/$(basename "$f")"; done
+```
+
+Then `bin/rails db:prepare`, which creates `storage/development.sqlite3` **and runs the seed** — a
+freshly created database is seeded automatically, so there is no need to call `db:seed` separately. The
+worktree gets its own `storage/`, so none of this touches the main checkout's development database.
+
 **Before deploying, note that `.dockerignore` does not exclude `db/*.csv`.** Docker's build context is
 the filesystem rather than git, so those files are baked into the image and pushed to whatever registry
 Kamal is configured with. Either exclude them and put the statements on the host, or satisfy yourself


### PR DESCRIPTION
`config/master.key` and `db/*.csv` are gitignored, so a fresh worktree has neither. `db:seed` then reports that it cannot find them and does nothing — deliberate, so a deploy does not fall over before the statements are in place, but it reads like a broken seed the first time you meet it.

Adds a **Setting up a new worktree** subsection under `## Commands`, immediately after the paragraph explaining what seeding needs:

- symlink the key and the statements from the main checkout rather than copying them, so the real financial data exists once on disk;
- the main checkout is derived with `dirname "$(git rev-parse --git-common-dir)"` rather than hardcoded, so no machine-specific absolute path enters a public repository;
- `bin/rails db:prepare` creates `storage/development.sqlite3` **and runs the seed** — a freshly created database is seeded automatically, so `db:seed` need not be called separately;
- `storage/` is per-worktree, so none of it touches the main checkout's development database.

Verified by doing it: this worktree now seeds to 2,626 transactions, 1,711 of them categorised. The individual commands were run; the two assembled shell lines were not executed verbatim, as this session's sandbox refuses compound commands inside a worktree.

Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)